### PR TITLE
Test with django 1.7, 1.8, and 1.9 too

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ env:
   - DJANGO='django<1.5'
   - DJANGO='django<1.6'
   - DJANGO='django<1.7'
+  - DJANGO='django<1.8'
+  - DJANGO='django<1.9'
+  - DJANGO='django>=1.9b1,<1.10'
 install:
   - pip install $DJANGO coverage coveralls
 script: coverage run --rcfile=.coveragerc runtests.py


### PR DESCRIPTION
1.9 (currently beta 1) will be release around 2015-12-01
See https://code.djangoproject.com/wiki/Version1.9Roadmap#schedule

1.8 is a LTS release
See https://www.djangoproject.com/weblog/2015/apr/01/release-18-final/